### PR TITLE
文档更新：添加 embeddinggemma Q4_0 模型支持

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,8 @@ curl -L -O https://huggingface.co/Qwen/Qwen3-Embedding-0.6B-GGUF/resolve/main/Qw
 wget https://huggingface.co/unsloth/embeddinggemma-300m-GGUF/resolve/main/embeddinggemma-300M-Q8_0.gguf
 # 或使用 curl
 curl -L -O https://huggingface.co/unsloth/embeddinggemma-300m-GGUF/resolve/main/embeddinggemma-300M-Q8_0.gguf
+
+curl -L -O https://huggingface.co/unsloth/embeddinggemma-300m-GGUF/resolve/main/embeddinggemma-300m-Q4_0.gguf
 ```
 
 ### 4. 构建项目

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build": "tsc",
     "start": "npm run node-ts -- src/index.ts",
     "start:gemma": "npm run node-ts -- src/index.ts --model ./models/embeddinggemma-300M-Q8_0.gguf",
+    "start:gemma:q4": "npm run node-ts -- src/index.ts --model ./models/embeddinggemma-300m-Q4_0.gguf",
     "start:build": "npm run build && node dist/index.js",
     "dev": "node --loader ts-node/esm --watch src/index.ts",
     "test": "npm run build && node scripts/test-functionality.js",


### PR DESCRIPTION
## What Changed
- 在 README.md 中添加了 embeddinggemma-300m-Q4_0 模型的下载命令
- 在 package.json 中添加了 start:gemma:q4 启动脚本

## Why
- 为用户提供更多模型选择，支持量化级别更低的 Q4_0 模型
- 方便用户快速启动和使用不同版本的 embeddinggemma 模型

## How to Test
1. 运行新增的下载命令：`curl -L -O https://huggingface.co/unsloth/embeddinggemma-300m-GGUF/resolve/main/embeddinggemma-300m-Q4_0.gguf`
2. 执行新增的启动命令：`npm run start:gemma:q4`
3. 验证项目能正常启动并使用 Q4_0 模型